### PR TITLE
Bump `skeptic` to latest version `0.13`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ winapi = "0.2.7"
 kernel32-sys = "0.2.2"
 
 [dev-dependencies]
-skeptic = "0.4"
+skeptic = "0.13"
 
 [build-dependencies]
-skeptic = "0.4"
+skeptic = "0.13"


### PR DESCRIPTION
`skeptic` version `0.4` shows up as a warning when using `cargo audit` due its dependency on the unmaintained `tempdir`. This bumps `skeptic`'s version to `0.13` which has the same interface but updated dependencies.